### PR TITLE
Remove fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "chokidar": "^1.6.0",
     "copy-paste": "^1.3.0",
     "debug": "^2.2.0",
-    "fs": "0.0.2",
     "imgur": "^0.1.7",
     "node-notifier": "^4.6.1",
     "path": "^0.11.14",


### PR DESCRIPTION
Heya, this package is a placeholder package on npm. Fs functionality is built-in so there's no need to put it in your list of dependencies.  More info on this can be found here:
- https://www.npmjs.com/package/fs
- http://status.npmjs.org/incidents/dw8cr1lwxkcr
